### PR TITLE
fix lint with NOLINT

### DIFF
--- a/src/network/hyperx/util.cc
+++ b/src/network/hyperx/util.cc
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "network/hyperx/util.h"
+#include "network/hyperx/util.h"  // NOLINT (build/include)
 
 #include <colhash/tuplehash.h>
 


### PR DESCRIPTION
Bypass cpplint check for src/network/hyperx/util.cc because it is getting confused with the .tcc file.