### PR TITLE
Fix num routers and router radix assumption in info logging

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -62,7 +62,7 @@ s32 main(s32 _argc, char** _argv) {
   u32 numRouters = network->numRouters();
   std::map<u32, u32> routerRadices;
   for (u32 routerId = 0; routerId < numRouters; routerId++) {
-    routerRadices[network->getRouter(0)->numPorts()] += 1;
+    routerRadices[network->getRouter(routerId)->numPorts()] += 1;
   }
   u32 numVcs = network->numVcs();
   u64 numComponents = Component::numComponents();

--- a/src/main.cc
+++ b/src/main.cc
@@ -60,13 +60,19 @@ s32 main(s32 _argc, char** _argv) {
   gSim->setNetwork(network);
   u32 numInterfaces = network->numInterfaces();
   u32 numRouters = network->numRouters();
-  u32 routerRadix = network->getRouter(0)->numPorts();
+  std::map<u32, u32> routerRadices;
+  for (u32 routerId = 0; routerId < numRouters; routerId++) {
+    routerRadices[network->getRouter(0)->numPorts()] += 1;
+  }
   u32 numVcs = network->numVcs();
   u64 numComponents = Component::numComponents();
 
   gSim->infoLog.logInfo("Endpoints", std::to_string(numInterfaces));
   gSim->infoLog.logInfo("Routers", std::to_string(numRouters));
-  gSim->infoLog.logInfo("Router0 Radix", std::to_string(routerRadix));
+  for (auto& p : routerRadices) {
+    gSim->infoLog.logInfo("Router radix " + std::to_string(p.first),
+                          std::to_string(p.second));
+  }
   gSim->infoLog.logInfo("VCs", std::to_string(numVcs));
   gSim->infoLog.logInfo("Components", std::to_string(numComponents));
 

--- a/src/network/dragonfly/Network.cc
+++ b/src/network/dragonfly/Network.cc
@@ -310,8 +310,8 @@ u32 Network::numInterfaces() const {
 Router* Network::getRouter(u32 _id) const {
   std::vector<u32> routerAddress;
   translateRouterIdToAddress(_id, &routerAddress);
-  u32 g = routerAddress.at(0);
-  u32 r = routerAddress.at(1);
+  u32 g = routerAddress.at(1);
+  u32 r = routerAddress.at(0);
   return routers_.at(g).at(r);
 }
 


### PR DESCRIPTION
Fixes #5. Modified main.cc to read all router radices and print distribution. Will work with zero routers as well. Here is a sample output of a InfoLog:

```
Endpoints,60                                   
Routers,45                                                
Router radix 7,45                                   
VCs,1                                          
Components,3316                                      
Total event count,26937118 
Total sim units,55995000                       
Total real seconds,6.407172
Events per real second,4204213.457067              
Events per sim unit,0.481063                                
Sim units per real second,8739425.373141      
```     

bazel test :* passes all unit tests
./scripts/run_examples.py passes all checks