### PR TITLE
Rename uno

### DIFF
--- a/config/singlerouter_ioq_blast_simplemem.json
+++ b/config/singlerouter_ioq_blast_simplemem.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "singlerouter",
+    "topology": "single_router",
     "concentration": 16,
     "protocol_classes": [
       {

--- a/config/singlerouter_ioq_blast_simplemem.json
+++ b/config/singlerouter_ioq_blast_simplemem.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "uno",
+    "topology": "singlerouter",
     "concentration": 16,
     "protocol_classes": [
       {

--- a/config/singlerouter_oq_blast_blast.json
+++ b/config/singlerouter_oq_blast_blast.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "singlerouter",
+    "topology": "single_router",
     "concentration": 16,
     "protocol_classes": [
       {

--- a/config/singlerouter_oq_blast_blast.json
+++ b/config/singlerouter_oq_blast_blast.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "uno",
+    "topology": "singlerouter",
     "concentration": 16,
     "protocol_classes": [
       {

--- a/src/network/singlerouter/DirectRoutingAlgorithm.cc
+++ b/src/network/singlerouter/DirectRoutingAlgorithm.cc
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "network/uno/DirectRoutingAlgorithm.h"
+#include "network/singlerouter/DirectRoutingAlgorithm.h"
 
 #include <factory/ObjectFactory.h>
 
@@ -23,7 +23,7 @@
 #include "types/Packet.h"
 #include "types/Message.h"
 
-namespace Uno {
+namespace SingleRouter {
 
 DirectRoutingAlgorithm::DirectRoutingAlgorithm(
     const std::string& _name, const Component* _parent, Router* _router,
@@ -71,8 +71,8 @@ void DirectRoutingAlgorithm::processRequest(
   }
 }
 
-}  // namespace Uno
+}  // namespace SingleRouter
 
 registerWithObjectFactory(
-    "direct", Uno::RoutingAlgorithm,
-    Uno::DirectRoutingAlgorithm, UNO_ROUTINGALGORITHM_ARGS);
+    "direct", SingleRouter::RoutingAlgorithm,
+    SingleRouter::DirectRoutingAlgorithm, SINGLEROUTER_ROUTINGALGORITHM_ARGS);

--- a/src/network/singlerouter/DirectRoutingAlgorithm.h
+++ b/src/network/singlerouter/DirectRoutingAlgorithm.h
@@ -12,8 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NETWORK_UNO_DIRECTROUTINGALGORITHM_H_
-#define NETWORK_UNO_DIRECTROUTINGALGORITHM_H_
+#ifndef NETWORK_SINGLEROUTER_DIRECTROUTINGALGORITHM_H_
+#define NETWORK_SINGLEROUTER_DIRECTROUTINGALGORITHM_H_
 
 #include <json/json.h>
 #include <prim/prim.h>
@@ -21,12 +21,12 @@
 #include <string>
 
 #include "event/Component.h"
-#include "network/uno/RoutingAlgorithm.h"
+#include "network/singlerouter/RoutingAlgorithm.h"
 #include "router/Router.h"
 
-namespace Uno {
+namespace SingleRouter {
 
-class DirectRoutingAlgorithm : public Uno::RoutingAlgorithm {
+class DirectRoutingAlgorithm : public SingleRouter::RoutingAlgorithm {
  public:
   DirectRoutingAlgorithm(
       const std::string& _name, const Component* _parent, Router* _router,
@@ -42,6 +42,6 @@ class DirectRoutingAlgorithm : public Uno::RoutingAlgorithm {
   const bool adaptive_;
 };
 
-}  // namespace Uno
+}  // namespace SingleRouter
 
-#endif  // NETWORK_UNO_DIRECTROUTINGALGORITHM_H_
+#endif  // NETWORK_SINGLEROUTER_DIRECTROUTINGALGORITHM_H_

--- a/src/network/singlerouter/Network.cc
+++ b/src/network/singlerouter/Network.cc
@@ -155,5 +155,5 @@ void Network::collectChannels(std::vector<Channel*>* _channels) {
 
 }  // namespace SingleRouter
 
-registerWithObjectFactory("singlerouter", ::Network,
+registerWithObjectFactory("single_router", ::Network,
                           SingleRouter::Network, NETWORK_ARGS);

--- a/src/network/singlerouter/Network.cc
+++ b/src/network/singlerouter/Network.cc
@@ -12,7 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "network/uno/Network.h"
+#include "network/singlerouter/Network.h"
 
 #include <factory/ObjectFactory.h>
 
@@ -21,9 +21,9 @@
 
 #include <tuple>
 
-#include "network/uno/RoutingAlgorithm.h"
+#include "network/singlerouter/RoutingAlgorithm.h"
 
-namespace Uno {
+namespace SingleRouter {
 
 Network::Network(const std::string& _name, const Component* _parent,
                  MetadataHandler* _metadataHandler, Json::Value _settings)
@@ -153,7 +153,7 @@ void Network::collectChannels(std::vector<Channel*>* _channels) {
   }
 }
 
-}  // namespace Uno
+}  // namespace SingleRouter
 
-registerWithObjectFactory("uno", ::Network,
-                          Uno::Network, NETWORK_ARGS);
+registerWithObjectFactory("singlerouter", ::Network,
+                          SingleRouter::Network, NETWORK_ARGS);

--- a/src/network/singlerouter/Network.h
+++ b/src/network/singlerouter/Network.h
@@ -12,8 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NETWORK_UNO_NETWORK_H_
-#define NETWORK_UNO_NETWORK_H_
+#ifndef NETWORK_SINGLEROUTER_NETWORK_H_
+#define NETWORK_SINGLEROUTER_NETWORK_H_
 
 #include <json/json.h>
 #include <prim/prim.h>
@@ -27,7 +27,7 @@
 #include "network/Network.h"
 #include "router/Router.h"
 
-namespace Uno {
+namespace SingleRouter {
 
 class Network : public ::Network {
  public:
@@ -67,6 +67,6 @@ class Network : public ::Network {
   std::vector<Interface*> interfaces_;
 };
 
-}  // namespace Uno
+}  // namespace SingleRouter
 
-#endif  // NETWORK_UNO_NETWORK_H_
+#endif  // NETWORK_SINGLEROUTER_NETWORK_H_

--- a/src/network/singlerouter/RoutingAlgorithm.cc
+++ b/src/network/singlerouter/RoutingAlgorithm.cc
@@ -12,11 +12,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "network/uno/RoutingAlgorithm.h"
+#include "network/singlerouter/RoutingAlgorithm.h"
 
 #include <factory/ObjectFactory.h>
 
-namespace Uno {
+namespace SingleRouter {
 
 RoutingAlgorithm::RoutingAlgorithm(
     const std::string& _name, const Component* _parent, Router* _router,
@@ -37,16 +37,17 @@ RoutingAlgorithm* RoutingAlgorithm::create(
 
   // attempt to create the routing algorithm
   RoutingAlgorithm* ra = factory::ObjectFactory<
-    RoutingAlgorithm, UNO_ROUTINGALGORITHM_ARGS>::create(
+    RoutingAlgorithm, SINGLEROUTER_ROUTINGALGORITHM_ARGS>::create(
         algorithm, _name, _parent, _router, _baseVc, _numVcs, _inputPort,
         _inputVc, _concentration, _settings);
 
   // check that the factory had this type
   if (ra == nullptr) {
-    fprintf(stderr, "invalid Uno routing algorithm: %s\n", algorithm.c_str());
+    fprintf(stderr, "invalid SingleRouter routing algorithm: %s\n",
+            algorithm.c_str());
     assert(false);
   }
   return ra;
 }
 
-}  // namespace Uno
+}  // namespace SingleRouter

--- a/src/network/singlerouter/RoutingAlgorithm.h
+++ b/src/network/singlerouter/RoutingAlgorithm.h
@@ -12,8 +12,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef NETWORK_UNO_ROUTINGALGORITHM_H_
-#define NETWORK_UNO_ROUTINGALGORITHM_H_
+#ifndef NETWORK_SINGLEROUTER_ROUTINGALGORITHM_H_
+#define NETWORK_SINGLEROUTER_ROUTINGALGORITHM_H_
 
 #include <json/json.h>
 #include <prim/prim.h>
@@ -24,10 +24,10 @@
 #include "routing/RoutingAlgorithm.h"
 #include "router/Router.h"
 
-#define UNO_ROUTINGALGORITHM_ARGS const std::string&, const Component*, \
-    Router*, u32, u32, u32, u32, u32, Json::Value
+#define SINGLEROUTER_ROUTINGALGORITHM_ARGS const std::string&, \
+    const Component*, Router*, u32, u32, u32, u32, u32, Json::Value
 
-namespace Uno {
+namespace SingleRouter {
 
 class RoutingAlgorithm : public ::RoutingAlgorithm {
  public:
@@ -37,13 +37,13 @@ class RoutingAlgorithm : public ::RoutingAlgorithm {
                    Json::Value _settings);
   virtual ~RoutingAlgorithm();
 
-  // this is a routing algorithm factory for the uno topology
-  static RoutingAlgorithm* create(UNO_ROUTINGALGORITHM_ARGS);
+  // this is a routing algorithm factory for the SingleRouter topology
+  static RoutingAlgorithm* create(SINGLEROUTER_ROUTINGALGORITHM_ARGS);
 
  protected:
   u32 concentration_;
 };
 
-}  // namespace Uno
+}  // namespace SingleRouter
 
-#endif  // NETWORK_UNO_ROUTINGALGORITHM_H_
+#endif  // NETWORK_SINGLEROUTER_ROUTINGALGORITHM_H_


### PR DESCRIPTION
Renamed network Uno to SingleRouter. Doing this to remove ambiguity for the future case of a single interface.

bazel test: * passes all unit tests
./scripts/run_examples.py passes all checks