### PR TITLE
Implemented InterfaceOnly network

### DIFF
--- a/config/interfaceonly1_ioq_blast.json
+++ b/config/interfaceonly1_ioq_blast.json
@@ -1,0 +1,166 @@
+{
+  "simulator": {
+    "channel_cycle_time": 3,
+    "router_cycle_time": 2,
+    "interface_cycle_time": 2,
+    "print_progress": true,
+    "print_interval": 1.0,  // seconds
+    "random_seed": 12345678,
+    "info_log": {
+      "file": null  // "info.csv"
+    }
+  },
+  "network": {
+    "topology": "interfaceonly",
+    "num_interfaces": 1,
+    "protocol_classes": [
+      {
+        "num_vcs": 2,
+        "routing": {
+          "algorithm": "direct",
+          "latency": 1,
+          "adaptive": true
+        }
+      }
+    ],
+    "external_channel": {
+      "latency": 2
+    },
+    "channel_log": {
+      "file": null  // "channels.csv"
+    },
+    "traffic_log": {
+      "file": null  // "traffic.csv"
+    },
+    "router": {
+      "architecture": "input_output_queued",
+      "congestion_sensor": {
+        "algorithm": "buffer_occupancy",
+        "latency": 1,
+        "granularity": 0,
+        "minimum": 0.0,
+        "offset": 0.0,
+        "mode": "normalized_vc"  // {normalized,absolute}_{port,vc}
+      },
+      "congestion_mode": "output_and_downstream",
+      "input_queue_mode": "fixed",  // fixed or tailored
+      "input_queue_depth": 8,
+      "vca_swa_wait": false,
+      "output_queue_depth": 20,
+      "crossbar": {
+        "latency": 1  // cycles
+      },
+      "vc_scheduler": {
+        "allocator": {
+          "type": "rc_separable",
+          "slip_latch": true,
+          "iterations": 1,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          },
+          "client_arbiter": {
+            "type": "lslp"
+          }
+        }
+      },
+      "crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      },
+      "output_crossbar": {
+        "latency": 1  // cycles
+      },
+      "output_crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      }
+    },
+    "interface": {
+      "type": "standard",
+      "adaptive": true,
+      "fixed_msg_vc": false,
+      "crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      },
+      "init_credits_mode": "$&(network.router.input_queue_mode)&$",
+      "init_credits": "$&(network.router.input_queue_depth)&$",
+      "crossbar": {
+        "latency": 1  // cycles
+      }
+    }
+  },
+  "metadata_handler": {
+    "type": "zero"
+  },
+  "workload": {
+    "message_log": {
+      "file": null  // "data.mpf.gz"
+    },
+    "applications": [
+      {
+        "type": "blast",
+        "warmup_threshold": 0.90,
+        "kill_on_saturation": false,
+        "log_during_saturation": false,
+        "blast_terminal": {
+          // requests
+          "request_protocol_class": 0,
+          "request_injection_rate": 0.45,
+          // responses
+          "enable_responses": false,
+          // warmup
+          "warmup_interval": 200,  // delivered flits
+          "warmup_window": 15,
+          "warmup_attempts": 20,
+          // traffic generation
+          "num_transactions": 500000,
+          "max_packet_size": 16,
+          "traffic_pattern": {
+            "type": "loopback"
+          },
+          "message_size_distribution": {
+            "type": "probability",
+            "message_sizes": [1, 8, 16, 32, 64],
+            "size_probabilities": [50, 25, 12.5, 6.25, 6.25]
+          }
+        },
+        "rate_log": {
+          "file": null  // "rates.csv"
+        }
+      }
+    ]
+  },
+  "debug": [
+    "Workload",
+    "Workload.Application_0"
+  ]
+}

--- a/config/interfaceonly1_ioq_blast.json
+++ b/config/interfaceonly1_ioq_blast.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "interfaceonly",
+    "topology": "interface_only",
     "num_interfaces": 1,
     "protocol_classes": [
       {
@@ -32,68 +32,6 @@
     "traffic_log": {
       "file": null  // "traffic.csv"
     },
-    "router": {
-      "architecture": "input_output_queued",
-      "congestion_sensor": {
-        "algorithm": "buffer_occupancy",
-        "latency": 1,
-        "granularity": 0,
-        "minimum": 0.0,
-        "offset": 0.0,
-        "mode": "normalized_vc"  // {normalized,absolute}_{port,vc}
-      },
-      "congestion_mode": "output_and_downstream",
-      "input_queue_mode": "fixed",  // fixed or tailored
-      "input_queue_depth": 8,
-      "vca_swa_wait": false,
-      "output_queue_depth": 20,
-      "crossbar": {
-        "latency": 1  // cycles
-      },
-      "vc_scheduler": {
-        "allocator": {
-          "type": "rc_separable",
-          "slip_latch": true,
-          "iterations": 1,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          },
-          "client_arbiter": {
-            "type": "lslp"
-          }
-        }
-      },
-      "crossbar_scheduler": {
-        "allocator": {
-          "type": "r_separable",
-          "slip_latch": true,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          }
-        },
-        "full_packet": false,
-        "packet_lock": true,
-        "idle_unlock": true
-      },
-      "output_crossbar": {
-        "latency": 1  // cycles
-      },
-      "output_crossbar_scheduler": {
-        "allocator": {
-          "type": "r_separable",
-          "slip_latch": true,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          }
-        },
-        "full_packet": false,
-        "packet_lock": true,
-        "idle_unlock": true
-      }
-    },
     "interface": {
       "type": "standard",
       "adaptive": true,
@@ -111,8 +49,8 @@
         "packet_lock": true,
         "idle_unlock": true
       },
-      "init_credits_mode": "$&(network.router.input_queue_mode)&$",
-      "init_credits": "$&(network.router.input_queue_depth)&$",
+      "init_credits_mode": "fixed",
+      "init_credits": 8,
       "crossbar": {
         "latency": 1  // cycles
       }

--- a/config/interfaceonly2_ioq_blast.json
+++ b/config/interfaceonly2_ioq_blast.json
@@ -1,0 +1,166 @@
+{
+  "simulator": {
+    "channel_cycle_time": 3,
+    "router_cycle_time": 2,
+    "interface_cycle_time": 2,
+    "print_progress": true,
+    "print_interval": 1.0,  // seconds
+    "random_seed": 12345678,
+    "info_log": {
+      "file": null  // "info.csv"
+    }
+  },
+  "network": {
+    "topology": "interfaceonly",
+    "num_interfaces": 2,
+    "protocol_classes": [
+      {
+        "num_vcs": 2,
+        "routing": {
+          "algorithm": "direct",
+          "latency": 1,
+          "adaptive": true
+        }
+      }
+    ],
+    "external_channel": {
+      "latency": 2
+    },
+    "channel_log": {
+      "file": null  // "channels.csv"
+    },
+    "traffic_log": {
+      "file": null  // "traffic.csv"
+    },
+    "router": {
+      "architecture": "input_output_queued",
+      "congestion_sensor": {
+        "algorithm": "buffer_occupancy",
+        "latency": 1,
+        "granularity": 0,
+        "minimum": 0.0,
+        "offset": 0.0,
+        "mode": "normalized_vc"  // {normalized,absolute}_{port,vc}
+      },
+      "congestion_mode": "output_and_downstream",
+      "input_queue_mode": "fixed",  // fixed or tailored
+      "input_queue_depth": 8,
+      "vca_swa_wait": false,
+      "output_queue_depth": 20,
+      "crossbar": {
+        "latency": 1  // cycles
+      },
+      "vc_scheduler": {
+        "allocator": {
+          "type": "rc_separable",
+          "slip_latch": true,
+          "iterations": 1,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          },
+          "client_arbiter": {
+            "type": "lslp"
+          }
+        }
+      },
+      "crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      },
+      "output_crossbar": {
+        "latency": 1  // cycles
+      },
+      "output_crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      }
+    },
+    "interface": {
+      "type": "standard",
+      "adaptive": true,
+      "fixed_msg_vc": false,
+      "crossbar_scheduler": {
+        "allocator": {
+          "type": "r_separable",
+          "slip_latch": true,
+          "resource_arbiter": {
+            "type": "comparing",
+            "greater": false
+          }
+        },
+        "full_packet": false,
+        "packet_lock": true,
+        "idle_unlock": true
+      },
+      "init_credits_mode": "$&(network.router.input_queue_mode)&$",
+      "init_credits": "$&(network.router.input_queue_depth)&$",
+      "crossbar": {
+        "latency": 1  // cycles
+      }
+    }
+  },
+  "metadata_handler": {
+    "type": "zero"
+  },
+  "workload": {
+    "message_log": {
+      "file": null  // "data.mpf.gz"
+    },
+    "applications": [
+      {
+        "type": "blast",
+        "warmup_threshold": 0.90,
+        "kill_on_saturation": false,
+        "log_during_saturation": false,
+        "blast_terminal": {
+          // requests
+          "request_protocol_class": 0,
+          "request_injection_rate": 0.45,
+          // responses
+          "enable_responses": false,
+          // warmup
+          "warmup_interval": 200,  // delivered flits
+          "warmup_window": 15,
+          "warmup_attempts": 20,
+          // traffic generation
+          "num_transactions": 300000,
+          "max_packet_size": 16,
+          "traffic_pattern": {
+            "type": "bit_complement"
+          },
+          "message_size_distribution": {
+            "type": "probability",
+            "message_sizes": [1, 8, 16, 32, 64],
+            "size_probabilities": [50, 25, 12.5, 6.25, 6.25]
+          }
+        },
+        "rate_log": {
+          "file": null  // "rates.csv"
+        }
+      }
+    ]
+  },
+  "debug": [
+    "Workload",
+    "Workload.Application_0"
+  ]
+}

--- a/config/interfaceonly2_ioq_blast.json
+++ b/config/interfaceonly2_ioq_blast.json
@@ -11,7 +11,7 @@
     }
   },
   "network": {
-    "topology": "interfaceonly",
+    "topology": "interface_only",
     "num_interfaces": 2,
     "protocol_classes": [
       {
@@ -32,68 +32,6 @@
     "traffic_log": {
       "file": null  // "traffic.csv"
     },
-    "router": {
-      "architecture": "input_output_queued",
-      "congestion_sensor": {
-        "algorithm": "buffer_occupancy",
-        "latency": 1,
-        "granularity": 0,
-        "minimum": 0.0,
-        "offset": 0.0,
-        "mode": "normalized_vc"  // {normalized,absolute}_{port,vc}
-      },
-      "congestion_mode": "output_and_downstream",
-      "input_queue_mode": "fixed",  // fixed or tailored
-      "input_queue_depth": 8,
-      "vca_swa_wait": false,
-      "output_queue_depth": 20,
-      "crossbar": {
-        "latency": 1  // cycles
-      },
-      "vc_scheduler": {
-        "allocator": {
-          "type": "rc_separable",
-          "slip_latch": true,
-          "iterations": 1,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          },
-          "client_arbiter": {
-            "type": "lslp"
-          }
-        }
-      },
-      "crossbar_scheduler": {
-        "allocator": {
-          "type": "r_separable",
-          "slip_latch": true,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          }
-        },
-        "full_packet": false,
-        "packet_lock": true,
-        "idle_unlock": true
-      },
-      "output_crossbar": {
-        "latency": 1  // cycles
-      },
-      "output_crossbar_scheduler": {
-        "allocator": {
-          "type": "r_separable",
-          "slip_latch": true,
-          "resource_arbiter": {
-            "type": "comparing",
-            "greater": false
-          }
-        },
-        "full_packet": false,
-        "packet_lock": true,
-        "idle_unlock": true
-      }
-    },
     "interface": {
       "type": "standard",
       "adaptive": true,
@@ -111,8 +49,8 @@
         "packet_lock": true,
         "idle_unlock": true
       },
-      "init_credits_mode": "$&(network.router.input_queue_mode)&$",
-      "init_credits": "$&(network.router.input_queue_depth)&$",
+      "init_credits_mode": "fixed",
+      "init_credits": 8,
       "crossbar": {
         "latency": 1  // cycles
       }

--- a/src/network/interfaceonly/Network.cc
+++ b/src/network/interfaceonly/Network.cc
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "network/interfaceonly/Network.h"
+
+#include <factory/ObjectFactory.h>
+
+#include <cassert>
+#include <cmath>
+
+#include <tuple>
+
+namespace InterfaceOnly {
+
+Network::Network(const std::string& _name, const Component* _parent,
+                 MetadataHandler* _metadataHandler, Json::Value _settings)
+    : ::Network(_name, _parent, _metadataHandler, _settings) {
+  // num_interfaces
+  num_interfaces_ = _settings["num_interfaces"].asUInt();
+  assert(num_interfaces_ > 0);
+  assert(num_interfaces_ <= 2);
+  dbgprintf("num_interfaces_ = %u", num_interfaces_);
+
+  // parse the protocol classes description
+  loadProtocolClassInfo(_settings["protocol_classes"]);
+
+  // create the interfaces
+  interfaces_.resize(num_interfaces_, nullptr);
+  for (u32 id = 0; id < num_interfaces_; id++) {
+    // create the interface
+    std::string interfaceName = "Interface_" + std::to_string(id);
+    Interface* interface = Interface::create(
+        interfaceName, this, id, {id}, numVcs_, protocolClassVcs_,
+        _metadataHandler, _settings["interface"]);
+    interfaces_.at(id) = interface;
+  }
+
+  // create the channels
+  for (u32 id = 0; id < num_interfaces_; id++) {
+    // create the single channels
+    std::string channelName = "Channel_" + std::to_string(id);
+    Channel* channel = new Channel(channelName, this, numVcs_,
+                                   _settings["external_channel"]);
+    externalChannels_.push_back(channel);
+  }
+
+  // connect the interface(s) and channel(s)
+  if (num_interfaces_ == 1) {
+    // a single interface is wired in loopback mode
+    Channel* channel = externalChannels_.at(0);
+    interfaces_.at(0)->setInputChannel(0, channel);
+    interfaces_.at(0)->setOutputChannel(0, channel);
+  } else {  // num_interfaces_ == 2
+    // two interfaces are wired directly together
+    Channel* channel0 = externalChannels_.at(0);
+    Channel* channel1 = externalChannels_.at(1);
+    interfaces_.at(0)->setOutputChannel(0, channel0);
+    interfaces_.at(1)->setInputChannel(0, channel0);
+    interfaces_.at(1)->setOutputChannel(0, channel1);
+    interfaces_.at(0)->setInputChannel(0, channel1);
+  }
+
+  // clear the protocol class info
+  clearProtocolClassInfo();
+}
+
+Network::~Network() {
+  for (auto it = interfaces_.begin(); it != interfaces_.end(); ++it) {
+    Interface* interface = *it;
+    delete interface;
+  }
+  for (auto it = externalChannels_.begin(); it != externalChannels_.end();
+       ++it) {
+    Channel* channel = *it;
+    delete channel;
+  }
+}
+
+::RoutingAlgorithm* Network::createRoutingAlgorithm(
+     u32 _inputPort, u32 _inputVc, const std::string& _name,
+     const Component* _parent, Router* _router) {
+  assert(false);  // routers aren't created thus this will never be called
+  return nullptr;
+}
+
+u32 Network::numRouters() const {
+  return 0;
+}
+
+u32 Network::numInterfaces() const {
+  return num_interfaces_;
+}
+
+Router* Network::getRouter(u32 _id) const {
+  assert(false);  // there are no routers
+  return nullptr;
+}
+
+Interface* Network::getInterface(u32 _id) const {
+  return interfaces_.at(_id);
+}
+
+void Network::translateInterfaceIdToAddress(
+    u32 _id, std::vector<u32>* _address) const {
+  _address->resize(1);
+  _address->at(0) = _id;
+}
+
+u32 Network::translateInterfaceAddressToId(
+    const std::vector<u32>* _address) const {
+  return _address->at(0);
+}
+
+void Network::translateRouterIdToAddress(
+    u32 _id, std::vector<u32>* _address) const {
+  assert(false);  // there are no routers
+}
+
+u32 Network::translateRouterAddressToId(
+    const std::vector<u32>* _address) const {
+  assert(false);  // there are no routers
+  return 0;
+}
+
+u32 Network::computeMinimalHops(const std::vector<u32>* _source,
+                                const std::vector<u32>* _destination) const {
+  return 0;
+}
+
+void Network::collectChannels(std::vector<Channel*>* _channels) {
+  for (auto it = externalChannels_.begin(); it != externalChannels_.end();
+       ++it) {
+    Channel* channel = *it;
+    _channels->push_back(channel);
+  }
+}
+
+}  // namespace InterfaceOnly
+
+registerWithObjectFactory("interfaceonly", ::Network,
+                          InterfaceOnly::Network, NETWORK_ARGS);

--- a/src/network/interfaceonly/Network.cc
+++ b/src/network/interfaceonly/Network.cc
@@ -148,5 +148,5 @@ void Network::collectChannels(std::vector<Channel*>* _channels) {
 
 }  // namespace InterfaceOnly
 
-registerWithObjectFactory("interfaceonly", ::Network,
+registerWithObjectFactory("interface_only", ::Network,
                           InterfaceOnly::Network, NETWORK_ARGS);

--- a/src/network/interfaceonly/Network.h
+++ b/src/network/interfaceonly/Network.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef NETWORK_INTERFACEONLY_NETWORK_H_
+#define NETWORK_INTERFACEONLY_NETWORK_H_
+
+#include <json/json.h>
+#include <prim/prim.h>
+
+#include <string>
+#include <vector>
+
+#include "event/Component.h"
+#include "interface/Interface.h"
+#include "network/Channel.h"
+#include "network/Network.h"
+#include "router/Router.h"
+
+namespace InterfaceOnly {
+
+class Network : public ::Network {
+ public:
+  Network(const std::string& _name, const Component* _parent,
+          MetadataHandler* _metadataHandler, Json::Value _settings);
+  ~Network();
+
+  // this is the routing algorithm factory for this network
+  ::RoutingAlgorithm* createRoutingAlgorithm(
+       u32 _inputPort, u32 _inputVc, const std::string& _name,
+       const Component* _parent, Router* _router) override;
+
+  // Network
+  u32 numRouters() const override;
+  u32 numInterfaces() const override;
+  Router* getRouter(u32 _id) const override;
+  Interface* getInterface(u32 _id) const override;
+  void translateInterfaceIdToAddress(
+      u32 _id, std::vector<u32>* _address) const override;
+  u32 translateInterfaceAddressToId(
+      const std::vector<u32>* _address) const override;
+  void translateRouterIdToAddress(
+      u32 _id, std::vector<u32>* _address) const override;
+  u32 translateRouterAddressToId(
+      const std::vector<u32>* _address) const override;
+  u32 computeMinimalHops(const std::vector<u32>* _source,
+                         const std::vector<u32>* _destination) const override;
+
+ protected:
+  void collectChannels(std::vector<Channel*>* _channels) override;
+
+ private:
+  u32 num_interfaces_;
+
+  std::vector<Channel*> externalChannels_;
+  std::vector<Interface*> interfaces_;
+};
+
+}  // namespace InterfaceOnly
+
+#endif  // NETWORK_INTERFACEONLY_NETWORK_H_


### PR DESCRIPTION
Created InterfaceOnly network. It has two modes based on the "num_interfaces" setting:
1. One interface wired in loopback.
2. Two interfaces wired back to back.

Because there is no router, the traffic pattern must be specially chosen to guarantee the messages are generated for the corresponding endpoint. I created two new JSON configurations for this case.

bazel test :* passes all unit tests
./scripts/run_examples.py **FAILS**. Waiting on #8.