### PR TITLE
Fix virtual destructor

### DIFF
--- a/src/routing/Reduction.h
+++ b/src/routing/Reduction.h
@@ -35,7 +35,7 @@ class Reduction : public Component {
   Reduction(const std::string& _name, const Component* _parent,
             const PortedDevice* _device, RoutingMode _mode,
             bool _ignoreDuplicates, Json::Value _settings);
-  ~Reduction();
+  virtual ~Reduction();
 
   // this is a reduction factory
   static Reduction* create(REDUCTION_ARGS);


### PR DESCRIPTION
Fixes #13 

Only src/routing/Reduction.h was found to have a missing virtual destructor.

PASSES: bazel test :*
PASSES: ./scripts/run_examples.py