### PR TITLE
Update Python min version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,7 +12,7 @@ for Windows or Mac, however, this is not officially supported.
 
 These installation instructions require the following software:
 - c++ (must support c++17)
-- python3 (3.6+)
+- python3 (3.7+)
 - bazel
 
 The following command installs the necessary software:


### PR DESCRIPTION
Update minimal Python version (numpy 1.20.1 requires Python >=3.7)
numpy 1.20.1 required by ssplot